### PR TITLE
Matrix clear bug.

### DIFF
--- a/src/MatrixUtility.cxx
+++ b/src/MatrixUtility.cxx
@@ -47,7 +47,7 @@ bool FileOutput(const matrix_f& A, const char* filename) {
     return success;
 }
 
-void clear(matrix_f A) {
+void clear(matrix_f& A) {
     for(uint i=0;i<A.size1();i++) for(uint j=0;j<A.size2();j++) A(i,j) = 0.0;
 }
 

--- a/src/MatrixUtility.h
+++ b/src/MatrixUtility.h
@@ -27,6 +27,6 @@ namespace MatrixUtility {
     inline uint cols(matrix_f A){ return A.size2();}
     bool FileOutput(const matrix_f& A, const char* filename);
     bool TextFileOutput(const matrix_f& A, const char* filename);
-    void clear(matrix_f A);
+    void clear(matrix_f& A);
 }
 #endif


### PR DESCRIPTION
MatrixUtility clear routine doesn't clear the matrix when passed not by reference. This routine is called once in Fingerprint.cxx:72 and doesn't clear the matrix. But, as soon as the matrix_f object is created at first time, it's zeroed already. But on the next calls the matrix_f object initialized with some random data and thus whole calculation fails.

This bug caused the fingerprint algorithm to fail after the first successful execution within one program.

Here is the testcase code which covers this bug:

``` cpp
#include <codegen/Codegen.h>
#include <iostream>
#include "codegen/AudioStreamInput.h"

void runGenerator()
{
FfmpegStreamInput * audio = new FfmpegStreamInput;
audio->ProcessFile("/tmp/song.wav", 0, 0);
Codegen * codegen = new Codegen(audio->getSamples(), audio->getNumSamples(), 0);
std::cout << "Code size: " << codegen->getCodeString().size() << std::endl;
delete codegen;
delete audio;
}

int main()
{
for (int i = 0; i != 10; ++i)
runGenerator();
return 0;
}
```

Compile it with command:
g++ main.cpp -o testcase -lcodegen
