### PR TITLE
Add CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,87 @@
+project(echoprint-codegen)
+cmake_minimum_required(VERSION 2.8)
+
+set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules )
+
+# Stage 0 - Find dependencies
+# Boost
+find_package(Boost REQUIRED )
+
+# TagLib
+find_package(Taglib REQUIRED)
+
+# Thread library ( pthreads or other )
+find_package( Threads REQUIRED )
+
+# FFMPEG
+find_package( FFMPEG REQUIRED )
+
+# ZLib
+find_package( ZLIB REQUIRED )
+
+# Add library
+set ( codegen_SOURCES
+    src/AudioBufferInput.cxx
+    src/AudioStreamInput.cxx
+    src/Base64.cxx
+    src/Codegen.cxx
+    src/Fingerprint.cxx
+    src/MatrixUtility.cxx
+    src/SubbandAnalysis.cxx
+    src/Whitening.cxx
+    )
+
+set ( codegen_HEADERS
+    src/AudioBufferInput.h
+    src/AudioStreamInput.h
+    src/Base64.h
+    src/Codegen.h
+    src/Fingerprint.h 
+    src/MatrixUtility.h 
+    src/SubbandAnalysis.h 
+    src/Whitening.h
+    )
+
+include_directories(
+    ${Boost_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${TAGLIB_INCLUDE_DIRS}
+    ${FFMPEG_INCLUDE_DIRS}
+    ${ZLIB_INCLUDE_DIRS}
+    )
+
+add_library( codegen SHARED ${codegen_SOURCES} )
+
+target_link_libraries( codegen
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${ZLIB_LIBRARIES}
+    )
+
+
+# Add executable
+set( echoprint_codegen_SOURCES
+    src/Metadata.cxx
+    src/main.cxx
+    )
+
+add_executable( echoprint-codegen
+    ${echoprint_codegen_SOURCES}
+    )
+target_link_libraries(
+    echoprint-codegen
+    ${TAGLIB_LIBRARIES}
+    ${FFMPEG_LIBRARIES}
+    codegen
+    )
+
+# Install library and executable
+install( TARGETS echoprint-codegen
+    RUNTIME DESTINATION bin
+    )
+
+install( TARGETS codegen
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    )
+

--- a/cmake/modules/COPYING-CMAKE-SCRIPTS
+++ b/cmake/modules/COPYING-CMAKE-SCRIPTS
@@ -1,0 +1,22 @@
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products 
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cmake/modules/FindFFMPEG.cmake
+++ b/cmake/modules/FindFFMPEG.cmake
@@ -1,0 +1,213 @@
+# - Try to find FFMPEG
+# Once done this will define
+#
+#  FFMPEG_FOUND - system has FFMPEG
+#  FFMPEG_INCLUDE_DIRS - the FFMPEG include directory
+#  FFMPEG_LIBRARIES - Link these to use FFMPEG
+#  FFMPEG_DEFINITIONS - Compiler switches required for using FFMPEG
+#
+#  Copyright (c) 2008 Andreas Schneider <mail@cynapses.org>
+#  Copyright (c) 2010 Christophe Giboudeaux <cgiboudeaux@gmail.com>
+#
+#  Redistribution and use is allowed according to the terms of the New
+#  BSD license.
+#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#
+
+if (FFMPEG_LIBRARIES AND FFMPEG_INCLUDE_DIRS)
+  # in cache already
+  set(FFMPEG_FOUND TRUE)
+else (FFMPEG_LIBRARIES AND FFMPEG_INCLUDE_DIRS)
+
+  # use pkg-config to get the directories and then use these values
+  # in the FIND_PATH() and FIND_LIBRARY() calls
+  if (NOT WIN32)
+    include(FindPkgConfig)
+    pkg_check_modules(_AVCODEC libavcodec)
+    pkg_check_modules(_AVFORMAT libavformat)
+    pkg_check_modules(_AVUTIL libavutil)
+    #pkg_check_modules(_POSTPROC libpostproc)
+    pkg_check_modules(_SWSCALE libswscale)
+
+  endif (NOT WIN32)
+
+  find_library(AVCODEC_LIBRARY
+    NAMES
+      avcodec
+    PATHS
+      ${_AVCODEC_LIBDIR}
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+    NO_DEFAULT_PATH
+  )
+
+  find_path(AVCODEC_INCLUDE_DIR
+    NAMES
+      avcodec.h
+    PATHS
+     ${_AVCODEC_INCLUDEDIR}
+      /usr/include
+      /usr/local/include
+      /opt/local/include
+      /sw/include
+    PATH_SUFFIXES
+      libavcodec
+      ffmpeg
+    NO_DEFAULT_PATH
+  )
+
+  if(AVCODEC_LIBRARY AND AVCODEC_INCLUDE_DIR)
+    set(AVCODEC_FOUND TRUE)
+    mark_as_advanced(AVCODEC_LIBRARY AVCODEC_INCLUDE_DIR)
+  endif(AVCODEC_LIBRARY AND AVCODEC_INCLUDE_DIR)
+
+  find_library(AVFORMAT_LIBRARY
+    NAMES
+      avformat
+    PATHS
+      ${_AVFORMAT_LIBDIR}
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+    NO_DEFAULT_PATH
+  )
+
+  find_path(AVFORMAT_INCLUDE_DIR
+    NAMES
+      avformat.h
+    PATHS
+      ${_AVFORMAT_INCLUDEDIR}
+      /usr/include
+      /usr/local/include
+      /opt/local/include
+      /sw/include
+    PATH_SUFFIXES
+      libavformat
+      ffmpeg
+    NO_DEFAULT_PATH
+  )
+
+  if(AVFORMAT_LIBRARY AND AVFORMAT_INCLUDE_DIR)
+    set(AVFORMAT_FOUND TRUE)
+    mark_as_advanced(AVFORMAT_LIBRARY AVFORMAT_INCLUDE_DIR)
+  endif(AVFORMAT_LIBRARY AND AVFORMAT_INCLUDE_DIR)
+
+  find_library(AVUTIL_LIBRARY
+    NAMES
+      avutil
+    PATHS
+      ${_AVUTIL_LIBDIR}
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+    NO_DEFAULT_PATH
+  )
+  mark_as_advanced(AVUTIL_LIBRARY)
+
+  find_path(AVUTIL_INCLUDE_DIR
+    NAMES
+      avutil.h
+    PATHS
+      ${_AVUTIL_INCLUDEDIR}
+      /usr/include
+      /usr/local/include
+      /opt/local/include
+      /sw/include
+    PATH_SUFFIXES
+      libavutil
+      ffmpeg
+    NO_DEFAULT_PATH
+  )
+
+  if(AVUTIL_LIBRARY AND AVUTIL_INCLUDE_DIR)
+    set(AVUTIL_FOUND TRUE)
+    mark_as_advanced(AVUTIL_LIBRARY AVUTIL_INCLUDE_DIR)
+  endif(AVUTIL_LIBRARY AND AVUTIL_INCLUDE_DIR)
+
+  find_library(SWSCALE_LIBRARY
+    NAMES
+      swscale
+    PATHS
+      ${_SWSCALE_LIBDIR}
+      /usr/lib
+      /usr/local/lib
+      /opt/local/lib
+      /sw/lib
+    NO_DEFAULT_PATH
+  )
+
+  find_path(SWSCALE_INCLUDE_DIR
+    NAMES
+      swscale.h
+    PATHS
+      ${_SWSCALE_INCLUDEDIR}
+      /usr/include
+      /usr/local/include
+      /opt/local/include
+      /sw/include
+    PATH_SUFFIXES
+      libswscale
+      ffmpeg
+    NO_DEFAULT_PATH
+  )
+
+  if(SWSCALE_LIBRARY AND SWSCALE_INCLUDE_DIR)
+    set(SWSCALE_FOUND TRUE)
+  mark_as_advanced(SWSCALE_LIBRARY SWSCALE_INCLUDE_DIR)
+  endif(SWSCALE_LIBRARY AND SWSCALE_INCLUDE_DIR)
+
+  #  find_library(POSTPROC_LIBRARY
+  #    NAMES
+  #      postproc
+  #    PATHS
+  #      ${_POSTPROC_LIBDIR}
+  #      /usr/lib
+  #      /usr/local/lib
+  #      /opt/local/lib
+  #      /sw/lib
+  #    NO_DEFAULT_PATH
+  #  )
+  #  mark_as_advanced(POSTPROC_LIBRARY)
+
+  #  find_path(POSTPROC_INCLUDE_DIR
+  #    NAMES
+  #      postprocess.h
+  #    PATHS
+  #      ${_POSTPROC_INCLUDEDIR}
+  #      /usr/include/postproc
+  #      /usr/local/include/postproc
+  #      /opt/local/include/postproc
+  #      /sw/include
+  #    PATH_SUFFIXES
+  #      libpostproc
+  #      ffmpeg
+  #  )
+  #  mark_as_advanced(POSTPROC_INCLUDE_DIR)
+
+  # if(POSTPROC_LIBRARY AND POSTPROC_INCLUDE_DIR)
+  #   set(SWSCALE_FOUND TRUE)
+  # mark_as_advanced(POSTPROC_LIBRARY POSTPROC_INCLUDE_DIR)
+  # endif(POSTPROC_LIBRARY AND POSTPROC_INCLUDE_DIR)
+
+  if(AVCODEC_FOUND AND AVFORMAT_FOUND AND AVUTIL_FOUND AND SWSCALE_FOUND)
+    set (FFMPEG_LIBRARIES
+        ${AVCODEC_LIBRARY}
+        ${AVFORMAT_LIBRARY}
+        ${AVUTIL_LIBRARY}
+        ${SWSCALE_LIBRARY}
+    )
+    set(FFMPEG_INCLUDE_DIRS
+        ${AVCODEC_INCLUDE_DIR}
+        ${AVFORMAT_INCLUDE_DIR}
+        ${AVUTIL_INCLUDE_DIR}
+        ${SWSCALE_INCLUDE_DIR}
+    )
+    set(FFMPEG_FOUND TRUE)
+    mark_as_advanced(FFMPEG_INCLUDE_DIRS FFMPEG_LIBRARIES)
+  endif(AVCODEC_FOUND AND AVFORMAT_FOUND AND AVUTIL_FOUND AND SWSCALE_FOUND)
+
+endif (FFMPEG_LIBRARIES AND FFMPEG_INCLUDE_DIRS)

--- a/cmake/modules/FindLibraryWithDebug.cmake
+++ b/cmake/modules/FindLibraryWithDebug.cmake
@@ -1,0 +1,113 @@
+#
+#  FIND_LIBRARY_WITH_DEBUG
+#  -> enhanced FIND_LIBRARY to allow the search for an
+#     optional debug library with a WIN32_DEBUG_POSTFIX similar
+#     to CMAKE_DEBUG_POSTFIX when creating a shared lib
+#     it has to be the second and third argument
+
+# Copyright (c) 2007, Christian Ehrlicher, <ch.ehrlicher@gmx.de>
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+MACRO(FIND_LIBRARY_WITH_DEBUG var_name win32_dbg_postfix_name dgb_postfix libname)
+
+  IF(NOT "${win32_dbg_postfix_name}" STREQUAL "WIN32_DEBUG_POSTFIX")
+
+     # no WIN32_DEBUG_POSTFIX -> simply pass all arguments to FIND_LIBRARY
+     FIND_LIBRARY(${var_name}
+                  ${win32_dbg_postfix_name}
+                  ${dgb_postfix}
+                  ${libname}
+                  ${ARGN}
+     )
+
+  ELSE(NOT "${win32_dbg_postfix_name}" STREQUAL "WIN32_DEBUG_POSTFIX")
+
+    IF(NOT WIN32)
+      # on non-win32 we don't need to take care about WIN32_DEBUG_POSTFIX
+
+      FIND_LIBRARY(${var_name} ${libname} ${ARGN})
+
+    ELSE(NOT WIN32)
+
+      # 1. get all possible libnames
+      SET(args ${ARGN})
+      SET(newargs "")
+      SET(libnames_release "")
+      SET(libnames_debug "")
+
+      LIST(LENGTH args listCount)
+
+      IF("${libname}" STREQUAL "NAMES")
+        SET(append_rest 0)
+        LIST(APPEND args " ")
+
+        FOREACH(i RANGE ${listCount})
+          LIST(GET args ${i} val)
+
+          IF(append_rest)
+            LIST(APPEND newargs ${val})
+          ELSE(append_rest)
+            IF("${val}" STREQUAL "PATHS")
+              LIST(APPEND newargs ${val})
+              SET(append_rest 1)
+            ELSE("${val}" STREQUAL "PATHS")
+              LIST(APPEND libnames_release "${val}")
+              LIST(APPEND libnames_debug   "${val}${dgb_postfix}")
+            ENDIF("${val}" STREQUAL "PATHS")
+          ENDIF(append_rest)
+
+        ENDFOREACH(i)
+
+      ELSE("${libname}" STREQUAL "NAMES")
+
+        # just one name
+        LIST(APPEND libnames_release "${libname}")
+        LIST(APPEND libnames_debug   "${libname}${dgb_postfix}")
+
+        SET(newargs ${args})
+
+      ENDIF("${libname}" STREQUAL "NAMES")
+
+      # search the release lib
+      FIND_LIBRARY(${var_name}_RELEASE
+                   NAMES ${libnames_release}
+                   ${newargs}
+      )
+
+      # search the debug lib
+      FIND_LIBRARY(${var_name}_DEBUG
+                   NAMES ${libnames_debug}
+                   ${newargs}
+      )
+
+      IF(${var_name}_RELEASE AND ${var_name}_DEBUG)
+
+        # both libs found
+        SET(${var_name} optimized ${${var_name}_RELEASE}
+                        debug     ${${var_name}_DEBUG})
+
+      ELSE(${var_name}_RELEASE AND ${var_name}_DEBUG)
+
+        IF(${var_name}_RELEASE)
+
+          # only release found
+          SET(${var_name} ${${var_name}_RELEASE})
+
+        ELSE(${var_name}_RELEASE)
+
+          # only debug (or nothing) found
+          SET(${var_name} ${${var_name}_DEBUG})
+
+        ENDIF(${var_name}_RELEASE)
+       
+      ENDIF(${var_name}_RELEASE AND ${var_name}_DEBUG)
+
+      MARK_AS_ADVANCED(${var_name}_RELEASE)
+      MARK_AS_ADVANCED(${var_name}_DEBUG)
+
+    ENDIF(NOT WIN32)
+
+  ENDIF(NOT "${win32_dbg_postfix_name}" STREQUAL "WIN32_DEBUG_POSTFIX")
+
+ENDMACRO(FIND_LIBRARY_WITH_DEBUG)

--- a/cmake/modules/FindTaglib.cmake
+++ b/cmake/modules/FindTaglib.cmake
@@ -1,0 +1,66 @@
+# - Try to find the Taglib library
+# Once done this will define
+#
+#  TAGLIB_FOUND - system has the taglib library
+#  TAGLIB_INCLUDE_DIRS - the taglib cflags
+#  TAGLIB_LIBRARIES - The libraries needed to use taglib
+
+# Copyright (c) 2006, Laurent Montel, <montel@kde.org>
+# Copyright (c) 2011, Serebriyskiy Artem, <v.for.vandal@gmail.com>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+if(NOT TAGLIB_MIN_VERSION)
+  set(TAGLIB_MIN_VERSION "1.4")
+endif(NOT TAGLIB_MIN_VERSION)
+
+if(NOT WIN32)
+    find_package(PkgConfig)
+    pkg_check_modules(PC_TAGLIB QUIET taglib)
+    set(TAGLIB_DEFINITIONS ${PC_TAGLIB_CFLAGS_OTHER})
+    set(TAGLIB_VERSION ${PC_TABLIG_VERSION})
+endif(NOT WIN32)
+
+#reset vars
+set(TAGLIB_LIBRARIES)
+
+
+include(FindLibraryWithDebug)
+include(FindPackageHandleStandardArgs)
+
+find_path(TAGLIB_INCLUDE_DIRS
+NAMES
+tag.h
+PATH_SUFFIXES taglib
+HINTS
+${KDE4_INCLUDE_DIR}
+${INCLUDE_INSTALL_DIR}
+${PC_TAGLIB_INCLUDE_DIRS}
+
+)
+
+find_library_with_debug(TAGLIB_LIBRARIES
+WIN32_DEBUG_POSTFIX d
+NAMES tag
+HINTS
+${KDE4_LIB_DIR}
+${LIB_INSTALL_DIR}
+${PC_TAGLIB_LIBRARY_DIRS}
+)
+
+find_package_handle_standard_args(Taglib DEFAULT_MSG 
+    TAGLIB_INCLUDE_DIRS TAGLIB_LIBRARIES)
+
+mark_as_advanced(TAGLIB_INCLUDE_DIRS TAGLIB_LIBRARIES)
+
+if(TAGLIB_FOUND)
+  if(NOT Taglib_FIND_QUIETLY )
+      message(STATUS "Taglib found: ${TAGLIB_LIBRARIES} Includes:  ${TAGLIB_INCLUDE_DIRS}")
+  endif(NOT Taglib_FIND_QUIETLY )
+else(TAGLIB_FOUND)
+  if(Taglib_FIND_REQUIRED)
+    message(FATAL_ERROR "Could not find Taglib")
+  endif(Taglib_FIND_REQUIRED)
+endif(TAGLIB_FOUND)
+


### PR DESCRIPTION
Descrpition:
Add files necessary for CMake build system to operate. This change doesn't break old src/Makefile build system.
This new system currently can work only on Linux( tested ). Additionaly CMake claims to be platform-independed, but no tests were done for Windows and Mac OS X building.

Summary
1. Add necessary CMakeLists.txt
2. Add necessary cmake FindXXX modules into cmake/modules
