### PR TITLE
Don't spawn a separate thread if there is only one input file

### DIFF
--- a/src/main.cxx
+++ b/src/main.cxx
@@ -250,13 +250,13 @@ int main(int argc, char** argv) {
         if(count == 0) throw std::runtime_error("No files given.\n");
 
 #ifdef _WIN32
+        // Threading doesn't work in windows yet.
         bool use_threads = false;
 #else
         bool use_threads = (count > 1);
 #endif
 
         if (!use_threads) {
-            // Threading doesn't work in windows yet.
             for(int i=0;i<count;i++) {
                 codegen_response_t* response = codegen_file((char*)files[i].c_str(), start_offset, duration, i);
                 char *output = make_json_string(response);


### PR DESCRIPTION
This patch changes the logic in main.cxx (for platforms where echoprint-codegen can spawn multiple threads) to only spawn threads when more than one file is being fingerprinted. This results in a significant speedup for a common use case where echoprint-codegen is ran once per input file.
