### PR TITLE
Quote filenames with single quotes on POSIX systems

### DIFF
--- a/src/AudioStreamInput.h
+++ b/src/AudioStreamInput.h
@@ -63,7 +63,9 @@ protected:
         // TODO: Windows
         std::string filestr = std::string(filename);
 #if defined(_WIN32) && !defined(__MINGW32__)
+        std::string quote = "\"";
 #else
+        std::string quote = "'";
         std::string::size_type next;
         std::string search = "'";
         std::string replace = "'\\''";
@@ -74,7 +76,7 @@ protected:
 #endif
         std::ostringstream message;
         // ffmpeg -i '%s' -ac %d -ar %d -f s16le (-t %d -ss %d) - 2>DEVNULL
-        message << "ffmpeg -i '" << filestr << "' ";
+        message << "ffmpeg -i " << quote << filestr << quote << " ";
         message << "-ac " << Params::AudioStreamInput::Channels << " ";
         message << "-ar " << (uint) Params::AudioStreamInput::SamplingRate << " ";
         message << "-f s16le ";


### PR DESCRIPTION
This should fix #27 and maybe #25. On POSIX systems at least, quoting popen parameters with single quotes and replacing single quotes inside the filename with `"'\\''"` results in the filename being passed exactly. I've tested it with files named with backticks and single quotes. (http://stackoverflow.com/a/35857)

Since most of the GetCommandLine method used std::string anyway, I moved from cstrings for easier find/replace.

Tested on OSX and Linux. Not tested on windows, but it shouldn't make things any worse off.
