### PR TITLE
Refactor code, details below

### DIFF
--- a/src/AudioBufferInput.cxx
+++ b/src/AudioBufferInput.cxx
@@ -3,11 +3,8 @@
 //  Copyright 2011 The Echo Nest Corporation. All rights reserved.
 //
 
-#include <string.h>
-#include <limits.h>
-#include <assert.h>
-
-
+#include <cstring>
+#include <climits>
 #include "AudioBufferInput.h"
 
 AudioBufferInput::AudioBufferInput() { }

--- a/src/AudioStreamInput.cxx
+++ b/src/AudioStreamInput.cxx
@@ -5,6 +5,7 @@
 
 
 
+#include <cstring>
 #include <stddef.h>
 #include <stdio.h>
 #include <iostream>
@@ -18,13 +19,9 @@
 #include <winsock.h>
 #define POPEN_MODE "rb"
 #endif
-#include <string.h>
-
 #include "AudioStreamInput.h"
 #include "Common.h"
 #include "Params.h"
-
-using std::string;
 
 namespace FFMPEG {
     // Do we think FFmpeg will read this as an audio file?
@@ -121,8 +118,7 @@ bool AudioStreamInput::ProcessFilePointer(FILE* pFile) {
     }
     assert(samplesLeft == 0);
 
-    int error = ferror(pFile);
-    bool success = error == 0;
+    bool success = (ferror(pFile) == 0);
 
     if (!success)
         perror("ProcessFilePointer error");

--- a/src/Codegen.cxx
+++ b/src/Codegen.cxx
@@ -19,9 +19,6 @@
 #include "Base64.h"
 #include <zlib.h>
 
-using std::string;
-using std::vector;
-
 Codegen::Codegen(const float* pcm, unsigned int numSamples, int start_offset) {
     if (Params::AudioStreamInput::MaxSamples < (uint)numSamples)
         throw std::runtime_error("File was too big\n");
@@ -47,7 +44,7 @@ Codegen::Codegen(const float* pcm, unsigned int numSamples, int start_offset) {
     delete pAudio;
 }
 
-string Codegen::createCodeString(vector<FPCode> vCodes) {
+std::string Codegen::createCodeString(std::vector<FPCode> vCodes) {
     if (vCodes.size() < 3) {
         return "";
     }
@@ -64,7 +61,7 @@ string Codegen::createCodeString(vector<FPCode> vCodes) {
 }
 
 
-string Codegen::compress(const string& s) {
+std::string Codegen::compress(const std::string& s) {
     long max_compressed_length = s.size()*2;
     unsigned char *compressed = new unsigned char[max_compressed_length];
 
@@ -85,7 +82,7 @@ string Codegen::compress(const string& s) {
     deflateEnd(&stream);
 
     // base64 the zlib'd code string
-    string encoded = base64_encode(compressed, compressed_length, true);
+    std::string encoded = base64_encode(compressed, compressed_length, true);
     delete [] compressed;
     return encoded;
 }

--- a/src/File.h
+++ b/src/File.h
@@ -6,7 +6,7 @@
 
 #ifndef FILE_H
 #define FILE_H
-#include <string.h>
+#include <cstring>
 #ifdef _WIN32
 #include "win_unistd.h"
 #else

--- a/src/Fingerprint.cxx
+++ b/src/Fingerprint.cxx
@@ -6,7 +6,7 @@
 
 #include "Fingerprint.h"
 #include "Params.h"
-#include <string.h>
+#include <cstring>
 
 #ifdef _WIN32
 #include "win_funcs.h"

--- a/src/main.cxx
+++ b/src/main.cxx
@@ -5,7 +5,7 @@
 
 
 #include <stdio.h>
-#include <string.h>
+#include <cstring>
 #include <memory>
 #ifndef _WIN32
     #include <libgen.h>
@@ -19,8 +19,6 @@
 #include "Codegen.h"
 #include <string>
 #define MAX_FILES 200000
-
-using namespace std;
 
 // The response from the codegen. Contains all the fields necessary
 // to create a json string.
@@ -116,7 +114,7 @@ codegen_response_t *codegen_file(char* filename, int start_offset, int duration,
     response->error = NULL;
     response->codegen = NULL;
 
-    auto_ptr<FfmpegStreamInput> pAudio(new FfmpegStreamInput());
+    std::auto_ptr<FfmpegStreamInput> pAudio(new FfmpegStreamInput());
     pAudio->ProcessFile(filename, start_offset, duration);
 
     if (pAudio.get() == NULL) { // Unable to decode!
@@ -143,7 +141,7 @@ codegen_response_t *codegen_file(char* filename, int start_offset, int duration,
     double t2 = now();
     Codegen *pCodegen = new Codegen(pAudio->getSamples(), numSamples, start_offset);
     t2 = now() - t2;
-    
+
     response->t1 = t1;
     response->t2 = t2;
     response->numSamples = numSamples;
@@ -152,7 +150,7 @@ codegen_response_t *codegen_file(char* filename, int start_offset, int duration,
     response->duration = duration;
     response->tag = tag;
     response->filename = filename;
-    
+
     return response;
 }
 
@@ -181,13 +179,13 @@ void print_json_to_screen(char* output, int count, int done) {
 }
 
 char *make_json_string(codegen_response_t* response) {
-    
+
     if (response->error != NULL) {
         return response->error;
     }
-    
+
     // Get the ID3 tag information.
-    auto_ptr<Metadata> pMetadata(new Metadata(response->filename));
+    std::auto_ptr<Metadata> pMetadata(new Metadata(response->filename));
 
     // preamble + codelen
     char* output = (char*) malloc(sizeof(char)*(16384 + strlen(response->codegen->getCodeString().c_str()) ));
@@ -220,7 +218,7 @@ char *make_json_string(codegen_response_t* response) {
 int main(int argc, char** argv) {
     if (argc < 2) {
         fprintf(stderr, "Usage: %s [ filename | -s ] [seconds_start] [seconds_duration] [< file_list (if -s is set)]\n", argv[0]);
-        exit(-1);
+        exit(EXIT_FAILURE);
     }
 
     try {
@@ -235,10 +233,10 @@ int main(int argc, char** argv) {
         if (argc > 4) already = atoi(argv[4]);
         // If you give it -s, it means to read in a list of files from stdin.
         if (strcmp(filename, "-s") == 0) {
-            while(cin) {
+            while(std::cin) {
                 if (count < MAX_FILES) {
                     string temp_str;
-                    getline(cin, temp_str);
+                    getline(std::cin, temp_str);
                     if (temp_str.size() > 2)
                         files[count++] = temp_str;
                 } else {


### PR DESCRIPTION
Refactored code

Modify string.h -> cstring
Use namespace to avoid conflicts
Use EXIT_FAILURE instead of exit(-1)
Remove redundant error variable since it is not used after initialised
