### PR TITLE
Move LDFLAGS after the main object

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -41,7 +41,7 @@ else
 endif
 
 echoprint-codegen: $(MODULES) main.o
-	$(CXX) $(MODULES) $(LDFLAGS) main.o -o ../echoprint-codegen
+	$(CXX) $(MODULES) main.o $(LDFLAGS) -o ../echoprint-codegen
 
 %.o: %.c %.h
 	$(CC) $(CFLAGS) -c -o $@ $<


### PR DESCRIPTION
In order to link correctly the libraries with the echoprint-codegen binary the libraries have to be after the object files.
