### PR TITLE
Simple getCodes() from Codegen object

### DIFF
--- a/src/Codegen.cxx
+++ b/src/Codegen.cxx
@@ -39,6 +39,7 @@ Codegen::Codegen(const float* pcm, unsigned int numSamples, int start_offset) {
     pFingerprint->Compute();
 
     _CodeString = createCodeString(pFingerprint->getCodes());
+    _vCodes = pFingerprint->getCodes();
     _NumCodes = pFingerprint->getCodes().size();
 
     delete pFingerprint;

--- a/src/Codegen.h
+++ b/src/Codegen.h
@@ -25,15 +25,17 @@
     #define CODEGEN_API
 #endif
 
+#include "FPCode.h"
+
 class Fingerprint;
 class SubbandAnalysis;
-struct FPCode;
 
 class CODEGEN_API Codegen {
 public:
     Codegen(const float* pcm, unsigned int numSamples, int start_offset);
 
     std::string getCodeString(){return _CodeString;}
+    std::vector<FPCode> const & getCodes() const {return _vCodes; }
     int getNumCodes(){return _NumCodes;}
     static double getVersion() { return ECHOPRINT_VERSION; }
 private:
@@ -42,6 +44,7 @@ private:
 
     std::string compress(const std::string& s);
     std::string _CodeString;
+    std::vector<FPCode> _vCodes;
     int _NumCodes;
 };
 

--- a/src/FPCode.cxx
+++ b/src/FPCode.cxx
@@ -1,0 +1,17 @@
+//
+//  echoprint-codegen
+//  Copyright 2011 The Echo Nest Corporation. All rights reserved.
+//
+
+
+#include "FPCode.h"
+
+FPCode::FPCode()
+    : frame(0), code(0) {}
+
+FPCode::FPCode(FPCode const & copy)
+    : frame( copy.frame), code( copy.code) {}
+
+FPCode::FPCode(uint32_t f, uint32_t c)
+    : frame(f), code(c) {}
+

--- a/src/FPCode.h
+++ b/src/FPCode.h
@@ -1,0 +1,19 @@
+//
+//  echoprint-codegen
+//  Copyright 2011 The Echo Nest Corporation. All rights reserved.
+//
+
+#ifndef FPCODE_H
+#define FPCODE_H
+
+#include <stdint.h>
+
+struct FPCode {
+    FPCode();
+    FPCode(FPCode const & copy);
+    FPCode(uint32_t f, uint32_t c);
+    uint32_t frame;
+    uint32_t code;
+};
+
+#endif /* FPCODE_H */

--- a/src/Fingerprint.h
+++ b/src/Fingerprint.h
@@ -19,12 +19,7 @@
 #define HASH_BITMASK 0x000fffff
 #define SUBBANDS 8
 
-struct FPCode {
-    FPCode() : frame(0), code(0) {}
-    FPCode(uint f, int c) : frame(f), code(c) {}
-    uint frame;
-    uint code;
-};
+#include "FPCode.h"
 
 unsigned int MurmurHash2 ( const void * key, int len, unsigned int seed );
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -22,6 +22,7 @@ MODULES_LIB = \
     AudioBufferInput.o \
     AudioStreamInput.o \
     Base64.o \
+    FPCode.o \
     Codegen.o \
     Fingerprint.o \
     MatrixUtility.o \
@@ -72,7 +73,7 @@ install: all
 	mkdir -p $(DESTDIR)$(BINDIR)
 	install ../echoprint-codegen $(DESTDIR)$(BINDIR)
 	install -d $(DESTDIR)$(INCLUDEDIR)/echoprint
-	install -pm 644 Codegen.h $(DESTDIR)$(INCLUDEDIR)/echoprint/
+	install -pm 644 FPCode.h Codegen.h $(DESTDIR)$(INCLUDEDIR)/echoprint/
 	mkdir -p $(DESTDIR)$(LIBDIR)
 ifeq ($(UNAME),Darwin)
 	install -m 755 libcodegen.$(VERSION).dylib $(DESTDIR)$(LIBDIR)


### PR DESCRIPTION
Allow to use codes directly from libcodegen.so without the need to decode the output string back
