### PR TITLE
fix for make file under Mac OS enviroment

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -9,7 +9,7 @@ CXX=g++
 CC=gcc
 #OPTFLAGS=-g -O0
 OPTFLAGS=-O3 -DBOOST_UBLAS_NDEBUG -DNDEBUG
-BOOST_CFLAGS=-I/usr/local/include/boost-1_35
+BOOST_CFLAGS=-I/opt/local/include
 TAGLIB_CFLAGS=`taglib-config --cflags`
 TAGLIB_LIBS=`taglib-config --libs`
 CXXFLAGS=-Wall $(BOOST_CFLAGS) $(TAGLIB_CFLAGS) -fPIC $(OPTFLAGS)
@@ -76,7 +76,7 @@ install: all
 	mkdir -p $(DESTDIR)$(LIBDIR)
 ifeq ($(UNAME),Darwin)
 	install -m 755 libcodegen.$(VERSION).dylib $(DESTDIR)$(LIBDIR)
-	ln -fs $(DESTDIR)$(LIBDIR)/libcodegen.$(VERSION) $(DESTDIR)$(LIBDIR)/libcodegen.$(VERSION_MAJ).dylib
+	ln -fs $(DESTDIR)$(LIBDIR)/libcodegen.$(VERSION).dylib $(DESTDIR)$(LIBDIR)/libcodegen.$(VERSION_MAJ).dylib
 	ln -fs $(DESTDIR)$(LIBDIR)/libcodegen.$(VERSION_MAJ).dylib $(DESTDIR)$(LIBDIR)/libcodegen.dylib
 else
 	install -m 755 $(LIBNAME).$(VERSION) $(DESTDIR)$(LIBDIR)


### PR DESCRIPTION
-the postfix .dylib while linking stage under Mac OS environment, which would result broken symbolic linkage
-the boost include dirs is located at /opt/local/include
